### PR TITLE
Add ability to execute as a module

### DIFF
--- a/callisto/__main__.py
+++ b/callisto/__main__.py
@@ -1,0 +1,4 @@
+import sys
+from callisto.callisto import cli
+
+sys.exit(cli())


### PR DESCRIPTION
Allows `python -m callisto`, which makes the python being used more explicit.